### PR TITLE
物件一覧ページのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,32 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import "@fortawesome/fontawesome-free/scss/regular";
 @import "@fortawesome/fontawesome-free/scss/solid";
 @import "@fortawesome/fontawesome-free/scss/brands";
+
+
+// リンク色消す
+.Editlink {
+  text-decoration: none;
+
+  color: #272343;
+
+  &:link {
+    text-decoration: none;
+    color: #272343;
+  }
+
+  &:visited {
+    text-decoration: none;
+    color: #272343;
+  }
+
+  &:hover {
+    text-decoration: none;
+    color: #272343;
+  }
+
+  &:active {
+    text-decoration: none;
+    color: #272343;
+  }
+
+}

--- a/app/views/houses/index.html.erb
+++ b/app/views/houses/index.html.erb
@@ -1,18 +1,11 @@
 <h1>投稿一覧</h1>
-
-
-
-
-
-
 <% @houses.each do |house| %>
 
-
-  <div class="card border-light mb-3 card-columns card-dec" style="max-width: 80%; border-width:5px 0 0 0;">
+  <%= link_to house, class:"card border-light mb-3 card-columns card-dec Editlink", style:"max-width: 80%; border-width:5px 0 0 0;" do %>
     <div class="card-header"><%= house.name %>/エリア</div>
     <div class="card-body">
       <div class="row">
-     <%= image_tag house.house_image.url,class:"col-3" %>
+        <%= image_tag house.house_image.url,class:"col-3" %>
         <div class="col-9 ">
           <p class="card-text">賃料 <%= house.house_rent %>円</p>
           <p class="card-text">アクセス <%= house.station %>駅 / 徒歩<%= house.access %>分</p>
@@ -21,7 +14,7 @@
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 <% end %>
 
 

--- a/app/views/houses/index.html.erb
+++ b/app/views/houses/index.html.erb
@@ -1,6 +1,5 @@
 <h1>投稿一覧</h1>
 <% @houses.each do |house| %>
-
   <%= link_to house, class:"card border-light mb-3 card-columns card-dec Editlink", style:"max-width: 80%; border-width:5px 0 0 0;" do %>
     <div class="card-header"><%= house.name %>/エリア</div>
     <div class="card-body">

--- a/app/views/houses/index.html.erb
+++ b/app/views/houses/index.html.erb
@@ -1,28 +1,27 @@
 <h1>投稿一覧</h1>
-<table>
-  <thead>
-    <tr>
-      <th scope="col">物件名</th>
-      <th scope="col">画像</th>
-      <th scope="col">家賃</th>
-      <th scope="col">最寄駅</th>
-      <th scope="col">最寄駅からの徒歩距離</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @houses.each do |house| %>
-      <tr>
-        <th scope="row"><%= house.name %></th>
-         <% if house.house_image? %>
-          <td><%= image_tag house.house_image.url %></td>
-         <% end %>
-        <td><%= house.house_rent %></td>
-        <td><%= house.station %></td>
-        <td><%= house.access %></td>
-        <td><%= link_to "詳細", house %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+
+
+
+
+
+
+<% @houses.each do |house| %>
+
+
+  <div class="card border-light mb-3 card-columns card-dec" style="max-width: 80%; border-width:5px 0 0 0;">
+    <div class="card-header"><%= house.name %>/エリア</div>
+    <div class="card-body">
+      <div class="row">
+     <%= image_tag house.house_image.url,class:"col-3" %>
+        <div class="col-9 ">
+          <p class="card-text">賃料 <%= house.house_rent %>円</p>
+          <p class="card-text">アクセス <%= house.station %>駅 / 徒歩<%= house.access %>分</p>
+          <p class="card-text">☆☆☆☆☆☆</p>
+          <p>最新の口コミ１件</p>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
 
 


### PR DESCRIPTION
## 実装内容
- bootstrapCARDを使って、レイアウトを古これ風に
- 写真サイズ変更
- 詳細ページへのリンク作成

## 参考資料

- bootstrap公式
  - [CARD](https://getbootstrap.jp/docs/4.2/components/card/)
- Qiita 
   - [Rails　link_toを文言ではなく範囲で指定する](https://qiita.com/krppppp/items/b11db5543636f07947c5)

## チェックリスト

- [x] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

